### PR TITLE
Fixes #2, use an indirect param rather than metafunc.addcall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 dist
 *.egg-info
 *.pyc
+*.pyo

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,12 @@ For example::
 This will attempt to run test_file.py 1000 times, but will stop as soon as a failure
 occurs.
 
+UnitTest Style Tests
+--------------------
+
+Unfortunately pytest-repeat is not able to work with unittest.TestCase test classes.
+These tests will simply always run once, regardless of `--count`, and show a warning.
+
 Resources
 ---------
 

--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -1,7 +1,10 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import warnings
+from unittest import TestCase
 
+import pytest
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -11,9 +14,34 @@ def pytest_addoption(parser):
         type='int',
         help='Number of times to repeat each test')
 
+class UnexpectedError(Exception):
+    pass
+
+@pytest.fixture(autouse=True)
+def __pytest_repeat_step_number(request):
+    if request.config.option.count > 1:
+        try:
+            return request.param
+        except AttributeError:
+            if issubclass(request.cls, TestCase):
+                warnings.warn(
+                    "Repeating unittest class tests not supported")
+            else:
+                raise UnexpectedError(
+                    "This call couldn't work with pytest-repeat. "
+                    "Please consider raising an issue with your usage.")
+
 
 def pytest_generate_tests(metafunc):
     count = metafunc.config.option.count
     if count > 1:
-        for i in range(count):
-            metafunc.addcall()
+
+        def make_progress_id(i, n=count):
+            return '{}/{}'.format(i + 1, n)
+
+        metafunc.parametrize(
+            '__pytest_repeat_step_number',
+            range(count),
+            indirect=True,
+            ids=make_progress_id
+        )

--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -10,7 +10,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--count',
         action='store',
-        default='1',
+        default=1,
         type='int',
         help='Number of times to repeat each test')
 
@@ -37,11 +37,11 @@ def pytest_generate_tests(metafunc):
     if count > 1:
 
         def make_progress_id(i, n=count):
-            return '{}/{}'.format(i + 1, n)
+            return '{0}/{1}'.format(i + 1, n)
 
         metafunc.parametrize(
             '__pytest_repeat_step_number',
             range(count),
             indirect=True,
-            ids=make_progress_id
+            ids=[make_progress_id(i) for i in range(count)]
         )

--- a/test_repeat.py
+++ b/test_repeat.py
@@ -9,11 +9,14 @@ class TestRepeat:
 
     def test_no_repeat(self, testdir):
         testdir.makepyfile("""
-            def test_repeat():
+            def test_no_repeat():
                 pass
         """)
-        result = testdir.runpytest()
-        result.stdout.fnmatch_lines(['*1 passed*'])
+        result = testdir.runpytest('-v', '--count', '1')
+        result.stdout.fnmatch_lines([
+            '*test_no_repeat.py::test_no_repeat PASSED*',
+            '*1 passed*',
+        ])
         assert result.ret == 0
 
     def test_can_repeat(self, testdir):
@@ -25,6 +28,51 @@ class TestRepeat:
         result.stdout.fnmatch_lines(['*2 passed*'])
         assert result.ret == 0
 
+    def test_parametrize(self, testdir):
+        testdir.makepyfile("""
+            import pytest
+            @pytest.mark.parametrize('x', ['a', 'b', 'c'])
+            def test_repeat(x):
+                pass
+        """)
+        result = testdir.runpytest('--count', '2')
+        result.stdout.fnmatch_lines(['*6 passed*'])
+        assert result.ret == 0
+
+    def test_parametrized_fixture(self, testdir):
+        testdir.makepyfile("""
+            import pytest
+            @pytest.fixture(params=['a', 'b', 'c'])
+            def parametrized_fixture(request):
+                return request.param
+
+            def test_repeat(parametrized_fixture):
+                pass
+        """)
+        result = testdir.runpytest('--count', '2')
+        result.stdout.fnmatch_lines(['*6 passed*'])
+        assert result.ret == 0
+
+    def test_step_number(self, testdir):
+        testdir.makepyfile("""
+            import pytest
+            expected_steps = iter(range(5))
+            def test_repeat(__pytest_repeat_step_number):
+                assert next(expected_steps) == __pytest_repeat_step_number
+                if __pytest_repeat_step_number == 4:
+                    assert not list(expected_steps)
+        """)
+        result = testdir.runpytest('-v', '--count', '5')
+        result.stdout.fnmatch_lines([
+            '*test_step_number.py::test_repeat?1/5? PASSED*',
+            '*test_step_number.py::test_repeat?2/5? PASSED*',
+            '*test_step_number.py::test_repeat?3/5? PASSED*',
+            '*test_step_number.py::test_repeat?4/5? PASSED*',
+            '*test_step_number.py::test_repeat?5/5? PASSED*',
+            '*5 passed*',
+        ])
+        assert result.ret == 0
+
     def test_invalid_option(self, testdir):
         testdir.makepyfile("""
             def test_repeat():
@@ -32,3 +80,17 @@ class TestRepeat:
         """)
         result = testdir.runpytest('--count', 'a')
         assert result.ret == 2
+
+    def test_unittest_test(self, testdir):
+        testdir.makepyfile("""
+            from unittest import TestCase
+
+            class ClassStyleTest(TestCase):
+                def test_this(self):
+                    assert 1
+        """)
+        result = testdir.runpytest('-v', '--count', '2')
+        result.stdout.fnmatch_lines([
+            '*test_unittest_test.py::ClassStyleTest::test_this PASSED*',
+            '*1 passed*',
+        ])

--- a/test_repeat.py
+++ b/test_repeat.py
@@ -14,7 +14,7 @@ class TestRepeat:
         """)
         result = testdir.runpytest('-v', '--count', '1')
         result.stdout.fnmatch_lines([
-            '*test_no_repeat.py::test_no_repeat PASSED*',
+            '*test_no_repeat.py:*:*test_no_repeat PASSED*',
             '*1 passed*',
         ])
         assert result.ret == 0
@@ -64,11 +64,11 @@ class TestRepeat:
         """)
         result = testdir.runpytest('-v', '--count', '5')
         result.stdout.fnmatch_lines([
-            '*test_step_number.py::test_repeat?1/5? PASSED*',
-            '*test_step_number.py::test_repeat?2/5? PASSED*',
-            '*test_step_number.py::test_repeat?3/5? PASSED*',
-            '*test_step_number.py::test_repeat?4/5? PASSED*',
-            '*test_step_number.py::test_repeat?5/5? PASSED*',
+            '*test_step_number.py:*:*test_repeat[[]1/5[]] PASSED*',
+            '*test_step_number.py:*:*test_repeat[[]2/5[]] PASSED*',
+            '*test_step_number.py:*:*test_repeat[[]3/5[]] PASSED*',
+            '*test_step_number.py:*:*test_repeat[[]4/5[]] PASSED*',
+            '*test_step_number.py:*:*test_repeat[[]5/5[]] PASSED*',
             '*5 passed*',
         ])
         assert result.ret == 0
@@ -91,6 +91,6 @@ class TestRepeat:
         """)
         result = testdir.runpytest('-v', '--count', '2')
         result.stdout.fnmatch_lines([
-            '*test_unittest_test.py::ClassStyleTest::test_this PASSED*',
+            '*test_unittest_test.py:*:*ClassStyleTest*test_this PASSED*',
             '*1 passed*',
         ])


### PR DESCRIPTION
Thanks to a suggestion from @RonnyPfannschmidt we replace `metafunc.addcall` with a new approach: an indirectly parametrized autouse fixture with a value like `range(count)`.

This allows pytest-repeat to work with parametrized tests and fixtures (#2)

We also address #3. It's not possible to repeat unittest style tests, but we make sure not to error, and raise a warning about this not being supported. 