### PR TITLE
Add ability to repeat parameterized tests

### DIFF
--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -15,5 +15,5 @@ def pytest_addoption(parser):
 def pytest_generate_tests(metafunc):
     count = metafunc.config.option.count
     if count > 1:
-        for i in range(count):
-            metafunc.addcall()
+        metafunc.fixturenames.append('tmp_ct')
+        metafunc.parametrize('tmp_ct', range(count))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pytest-repeat',
-      version='0.2',
+      version='0.3',
       description='pytest plugin for repeating tests',
       long_description=open('README.rst').read(),
       author='Bob Silverberg',

--- a/test_repeat.py
+++ b/test_repeat.py
@@ -25,6 +25,22 @@ class TestRepeat:
         result.stdout.fnmatch_lines(['*2 passed*'])
         assert result.ret == 0
 
+    def test_can_repeat_parameterized_test(self, testdir):
+        testdir.makepyfile("""
+            import pytest
+
+            @pytest.fixture(scope="function", params=["one", "two", "three"])
+            def fixture_with_params(request):
+                return request.param
+
+            def test_that_is_parametrized(request, fixture_with_params):
+                pass
+        """)
+        result = testdir.runpytest('--count', '2', '--collectonly')
+        result.stdout.fnmatch_lines(['*one-0*', '*one-1*', '*two-0*',
+                                     '*two-1*', '*three-0*', '*three-1*'])
+        assert result.ret == 0
+
     def test_invalid_option(self, testdir):
         testdir.makepyfile("""
             def test_repeat():


### PR DESCRIPTION
If you have a test that uses a parametrized fixture, such as:

```
    import pytest
    @pytest.fixture(scope="function", params=["one", "two", "three"])
    def fixture_with_params(request):
        return request.param

    def test_that_is_parametrized(request, fixture_with_params):
        pass
```

... and use the `--count` option when calling py.test, it has this effect:

```
py.test -k test_that_is_parametrized --count 2 --collectonly ./test_repeat.py
==================================== test session starts =====================================
platform darwin -- Python 2.7.11, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /Users/jladd/code/pytest-plugins/pytest-repeat, inifile:
plugins: repeat-0.2
collected 11 items
<Module 'test_repeat.py'>
  <Class 'TestRepeat'>
    <Instance '()'>
      <Function 'test_that_is_parametrized[one]'>
      <Function 'test_that_is_parametrized[two]'>
      <Function 'test_that_is_parametrized[three]'>
      <Function 'test_that_is_parametrized[3]'>          <------
      <Function 'test_that_is_parametrized[4]'>          <------
```

The repeat plug-in adds two additional calls to an un-parameterized version of the test. Here's a look at the existing code where you can see the additional calls being added.

```
        for i in range(count):
            metafunc.addcall()
```

This PR appends a temporary fixture to the set of existing fixtures. With the change, each parameterized test is repeated:

```
py.test -k test_that_is_parametrized --count 2 --collectonly ./test_repeat.py
================================================== test session starts ===================================================
platform darwin -- Python 2.7.11, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /Users/jladd/code/pytest-plugins/pytest-repeat, inifile:
plugins: repeat-0.4
collected 14 items
<Module 'test_repeat.py'>
  <Class 'TestRepeat'>
    <Instance '()'>
      <Function 'test_that_is_parametrized[one-0]'>
      <Function 'test_that_is_parametrized[one-1]'>
      <Function 'test_that_is_parametrized[two-0]'>
      <Function 'test_that_is_parametrized[two-1]'>
      <Function 'test_that_is_parametrized[three-0]'>
      <Function 'test_that_is_parametrized[three-1]'>
```