### PR TITLE
Use tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,23 @@
 language: python
+python:
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - pypy
+  - pypy3
+  - nightly
 env:
-  - TOXENV=py26-pytest28
-  - TOXENV=py26-pytest29
-  - TOXENV=py27-pytest28
-  - TOXENV=py27-pytest29
-  - TOXENV=py33-pytest28
-  - TOXENV=py33-pytest29
-  - TOXENV=py34-pytest28
-  - TOXENV=py34-pytest29
-  - TOXENV=py35-pytest28
-  - TOXENV=py35-pytest29
-  - TOXENV=pypy-pytest28
-  - TOXENV=pypy-pytest29
-  - TOXENV=pypy3-pytest28
-  - TOXENV=pypy3-pytest29
-  - TOXENV=flake8
+  - TOXENV=pytest28
+  - TOXENV=pytest29
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=flake8
+    - python: 3.5
+      env: TOXENV=flake8
 install:
-  - pip install tox
+  - pip install tox-travis
 script:
   - tox
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5


### PR DESCRIPTION
Using Travis python versions shows version numbers on the Travis
build page, instead of "no language set", and reduces the total
build time by a few minutes.

Run the flake8 test on 3.5 in addition to 2.7