### PR TITLE
Pass a type instead of string to parser.addoption

### DIFF
--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -12,7 +12,7 @@ def pytest_addoption(parser):
         '--count',
         action='store',
         default=1,
-        type='int',
+        type=int,
         help='Number of times to repeat each test')
 
 


### PR DESCRIPTION
Otherwise we get this DeprecationWarning with pytest 3.0:

      [...]
      File ".../pytest_repeat.py", line 16, in pytest_addoption
        help='Number of times to repeat each test')
      File ".../_pytest/config.py", line 482, in addoption
        self._anonymous.addoption(*opts, **attrs)
      File ".../_pytest/config.py", line 708, in addoption
        option = Argument(*optnames, **attrs)
      File ".../_pytest/config.py", line 609, in __init__
        stacklevel=3)
    DeprecationWarning: type argument to addoption() is a string 'int'. For parsearg this should be a type. (options: ('--count',))