### PR TITLE
Allow repeating a test using a decorator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 python:
-- 2.6
 - 2.7
-- 3.3
 - 3.4
 - 3.5
+- 3.6
 - pypy
 - pypy3
 - nightly

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,18 @@ your test, or tests, to be run:
 
 Each test collected by py.test will be run :code:`count` times.
 
+If you want to mark a test in your code to be repeated a number of times, you
+can use the :code:`@pytest.mark.repeat(count)` decorator:
+
+.. code-block:: python
+
+   import pytest
+
+
+   @pytest.mark.repeat(3)
+   def test_repeat_decorator():
+       pass
+
 Repeating a test until failure
 ------------------------------
 

--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -16,6 +16,12 @@ def pytest_addoption(parser):
         help='Number of times to repeat each test')
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        'markers',
+        'repeat(n): run the given test function `n` times.')
+
+
 class UnexpectedError(Exception):
     pass
 
@@ -37,6 +43,8 @@ def __pytest_repeat_step_number(request):
 
 def pytest_generate_tests(metafunc):
     count = metafunc.config.option.count
+    if hasattr(metafunc.function, 'repeat'):
+        count = int(metafunc.function.repeat.args[0])
     if count > 1:
 
         def make_progress_id(i, n=count):

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,7 @@ setup(name='pytest-repeat',
           'Topic :: Software Development :: Testing',
           'Topic :: Utilities',
           'Programming Language :: Python',
-          'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3.2',
-          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
-          'Programming Language :: Python :: 3.5'])
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6'])

--- a/test_repeat.py
+++ b/test_repeat.py
@@ -28,6 +28,23 @@ class TestRepeat:
         result.stdout.fnmatch_lines(['*2 passed*'])
         assert result.ret == 0
 
+    def test_mark_repeat_decorator_is_registered(self, testdir):
+        result = testdir.runpytest('--markers')
+        result.stdout.fnmatch_lines([
+            '@pytest.mark.repeat(n): run the given test function `n` times.'])
+        assert result.ret == 0
+
+    def test_mark_repeat_decorator(self, testdir):
+        testdir.makepyfile("""
+            import pytest
+            @pytest.mark.repeat(3)
+            def test_mark_repeat_decorator():
+                pass
+        """)
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(['*3 passed*'])
+        assert result.ret == 0
+
     def test_parametrize(self, testdir):
         testdir.makepyfile("""
             import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{26,27,33,34,35,py,py3}-pytest{29,30}, flake8
+envlist = py{27,34,35,36,py,py3}-pytest{29,30}, flake8
 
 [testenv]
 commands = py.test {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ commands = py.test {posargs}
 deps =
     pytest29: pytest==2.9.2
     pytest30: pytest==3.0.1
-    pytest-xdist
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest-repeat/issues/16.

Further changes (to make CI happy):

- Removed `pytest-xdist` dependency from `tox.ini` since it was not being used and it requires `pytest>=3` (conflicts with the current `pytest<3` tests).
- Removed unsupported Python 2.6 and 3.3 versions (which have reached end-of-life).
- Added new Python 3.6 to the test suite.

Python 3.7 has not been added because it is currently not available in Travis.