### PR TITLE
Move step number to the end of the parametrisation ID

### DIFF
--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -49,6 +49,7 @@ def __pytest_repeat_step_number(request):
                     "Please consider raising an issue with your usage.")
 
 
+@pytest.hookimpl(trylast=True)
 def pytest_generate_tests(metafunc):
     count = metafunc.config.option.count
     if hasattr(metafunc.function, 'repeat'):

--- a/test_repeat.py
+++ b/test_repeat.py
@@ -54,8 +54,16 @@ class TestRepeat:
             def test_repeat(x):
                 pass
         """)
-        result = testdir.runpytest('--count', '2')
-        result.stdout.fnmatch_lines(['*6 passed*'])
+        result = testdir.runpytest('-v', '--count', '2')
+        result.stdout.fnmatch_lines([
+            '*test_parametrize.py::test_repeat[[]a-1/2[]] PASSED*',
+            '*test_parametrize.py::test_repeat[[]a-2/2[]] PASSED*',
+            '*test_parametrize.py::test_repeat[[]b-1/2[]] PASSED*',
+            '*test_parametrize.py::test_repeat[[]b-2/2[]] PASSED*',
+            '*test_parametrize.py::test_repeat[[]c-1/2[]] PASSED*',
+            '*test_parametrize.py::test_repeat[[]c-2/2[]] PASSED*',
+            '*6 passed*',
+        ])
         assert result.ret == 0
 
     def test_parametrized_fixture(self, testdir):


### PR DESCRIPTION
This allows to sort test results on the report tool (Jenkins, Allure) with grouping by test name, not by step number.

For example we have next results:
```
test_parametrize.py::test_repeat[1/2-a]
test_parametrize.py::test_repeat[2/2-a]
test_parametrize.py::test_repeat[1/2-b]
test_parametrize.py::test_repeat[2/2-b]
test_parametrize.py::test_repeat[1/2-c]
test_parametrize.py::test_repeat[2/2-c]
```
After sorting it would looks like
```
test_parametrize.py::test_repeat[1/2-a]
test_parametrize.py::test_repeat[1/2-b]
test_parametrize.py::test_repeat[1/2-c]
test_parametrize.py::test_repeat[2/2-a]
test_parametrize.py::test_repeat[2/2-b]
test_parametrize.py::test_repeat[2/2-c]
```

With this patch results will looks like:
```
test_parametrize.py::test_repeat[a-1/2]
test_parametrize.py::test_repeat[a-2/2]
test_parametrize.py::test_repeat[b-1/2]
test_parametrize.py::test_repeat[b-2/2]
test_parametrize.py::test_repeat[c-1/2]
test_parametrize.py::test_repeat[c-2/2]
```
After sorting by name it still grouped by test and parameter.
