### PR TITLE
Update supported Python versions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,3 @@
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at http://mozilla.org/MPL/2.0/.
+file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 pytest-repeat
 ===================
 
-pytest-repeat is a plugin for `py.test <http://pytest.org>`_ that makes it easy
-to repeat a single test, or multiple tests, a specific number of times.
+pytest-repeat is a plugin for `py.test <https://docs.pytest.org>`_ that makes it
+easy to repeat a single test, or multiple tests, a specific number of times.
 
 .. image:: https://img.shields.io/badge/license-MPL%202.0-blue.svg
    :target: https://github.com/pytest-dev/pytest-repeat/blob/master/LICENSE
@@ -92,6 +92,6 @@ These tests will simply always run once, regardless of :code:`--count`, and show
 Resources
 ---------
 
-- `Release Notes <http://github.com/pytest-dev/pytest-repeat/blob/master/CHANGES.rst>`_
-- `Issue Tracker <http://github.com/pytest-dev/pytest-repeat/issues>`_
-- `Code <http://github.com/pytest-dev/pytest-repeat/>`_
+- `Release Notes <https://github.com/pytest-dev/pytest-repeat/blob/master/CHANGES.rst>`_
+- `Issue Tracker <https://github.com/pytest-dev/pytest-repeat/issues>`_
+- `Code <https://github.com/pytest-dev/pytest-repeat/>`_

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Requirements
 
 You will need the following prerequisites in order to use pytest-repeat:
 
-- Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5 or PyPy
+- Python 2.7, 3.4+ or PyPy
 - py.test 2.8 or newer
 
 Installation

--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -1,6 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 import warnings
 from unittest import TestCase
 

--- a/test_repeat.py
+++ b/test_repeat.py
@@ -1,6 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 import pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
+# Tox (https://tox.readthedocs.io/) is a tool for running tests
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.


### PR DESCRIPTION
EOL Python versions were dropped in https://github.com/pytest-dev/pytest-repeat/pull/22, so update README to match.

Also update HTTPS links and redirects.