### PR TITLE
Changed slash to - as test name is incompatible in a path.

### DIFF
--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -57,7 +57,7 @@ def pytest_generate_tests(metafunc):
     if count > 1:
 
         def make_progress_id(i, n=count):
-            return '{0}/{1}'.format(i + 1, n)
+            return '{0}-{1}'.format(i + 1, n)
 
         scope = metafunc.config.option.repeat_scope
         metafunc.parametrize(


### PR DESCRIPTION

When using "/", the name of the test generated will not be compatible to be used as a path.

For example creating a folder with the test's name containing test logs will not be possible.