### PR TITLE
Fix deprecation warnings and require pytest >= 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ python:
 - pypy3
 - nightly
 env:
-- TOXENV=pytest29
-- TOXENV=pytest30
+- TOXENV=pytest36
+- TOXENV=pytest37
+- TOXENV=pytest38
 matrix:
   include:
   - python: 2.7
@@ -30,4 +31,4 @@ deploy:
     tags: true
     repo: pytest-dev/pytest-repeat
     python: 3.5
-    condition: "$TOXENV = pytest30"
+    condition: "$TOXENV = pytest38"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Release Notes
 -------------
 
+**Unreleased**
+
+* Fix mark deprecation warnings in new pytest versions.
+
+* ``pytest-repeat`` now requires pytest>=3.6.
+
 **0.7.0 (2018-08-23)**
 
 * Move step number to the end of the parametrisation ID

--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -52,8 +52,9 @@ def __pytest_repeat_step_number(request):
 @pytest.hookimpl(trylast=True)
 def pytest_generate_tests(metafunc):
     count = metafunc.config.option.count
-    if hasattr(metafunc.function, 'repeat'):
-        count = int(metafunc.function.repeat.args[0])
+    m = metafunc.definition.get_closest_marker('repeat')
+    if m is not None:
+        count = int(m.args[0])
     if count > 1:
 
         def make_progress_id(i, n=count):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='pytest-repeat',
       py_modules=['pytest_repeat'],
       entry_points={'pytest11': ['repeat = pytest_repeat']},
       setup_requires=['setuptools_scm'],
-      install_requires=['pytest>=2.8.7'],
+      install_requires=['pytest>=3.6'],
       license='Mozilla Public License 2.0 (MPL 2.0)',
       keywords='py.test pytest repeat',
       classifiers=[

--- a/test_repeat.py
+++ b/test_repeat.py
@@ -106,7 +106,7 @@ class TestRepeat:
                 pass
         """)
         result = testdir.runpytest('--count', 'a')
-        assert result.ret == 2
+        assert result.ret == 4
 
     def test_unittest_test(self, testdir):
         testdir.makepyfile("""
@@ -256,4 +256,4 @@ class TestRepeat:
                 pass
         """)
         result = testdir.runpytest('--count', '2', '--repeat-scope', 'a')
-        assert result.ret == 2
+        assert result.ret == 4

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,16 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,34,35,36,py,py3}-pytest{29,30}, flake8
+envlist = py{27,34,35,36,py,py3}-pytest{36,37,38}, flake8
 
 [testenv]
-commands = py.test {posargs}
+commands = pytest {posargs}
 deps =
-    pytest29: pytest==2.9.2
-    pytest30: pytest==3.0.1
+    pytest36: pytest~=3.6
+    pytest37: pytest~=3.7
+    pytest38: pytest~=3.8
 
 [testenv:flake8]
 basepython = python
 deps = flake8
-commands = flake8 {posargs:.}
+commands = flake8 {posargs:pytest_repeat.py test_repeat.py}


### PR DESCRIPTION
I think it is OK to require new pytest versions instead of having to support
older versions.

Fix #29