### PR TITLE
Handle the case when some functions have repeat count of 1

### DIFF
--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -36,7 +36,11 @@ class UnexpectedError(Exception):
 
 @pytest.fixture(autouse=True)
 def __pytest_repeat_step_number(request):
-    if request.config.option.count > 1:
+    count = request.config.option.count
+    if hasattr(request.function, 'repeat'):
+        count = int(request.function.repeat.args[0])
+    if count > 1:
+
         try:
             return request.param
         except AttributeError:


### PR DESCRIPTION
In our use case, we have a setup function which only needs to run once, but the other tests all use the global repeat count. By adding pytest markers, I can have different repeat counts for various functions, so this PR handles the case when some of those repeat counts are equal to 1.