### PR TITLE
Run tests against pytest 3 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ python:
 - pypy
 - pypy3
 - nightly
-env:
-- TOXENV=pytest29
-- TOXENV=pytest30
 matrix:
   include:
   - python: 2.7
@@ -30,4 +27,3 @@ deploy:
     tags: true
     repo: pytest-dev/pytest-repeat
     python: 3.5
-    condition: "$TOXENV = pytest30"

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,34,35,36,py,py3}-pytest{29,30}, flake8
+envlist = py{27,34,35,36,py,py3}, flake8
 
 [testenv]
-commands = py.test {posargs}
+commands = pytest {posargs}
 deps =
-    pytest29: pytest==2.9.2
-    pytest30: pytest==3.0.1
+    pytest==3.7.4
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
As suggested in https://github.com/pytest-dev/pytest-repeat/pull/22#issuecomment-406196531:

> Thanks @Peque I'll merge this and prepare a release. If you're interested in contributing more, I think we can drop pytest 2.x from the `tox.ini` and `.travis.yml` and just run against the latest pytest release.

This PR drops pytest 2.x from `tox.ini` and `.travis.yml` but does not change the test suite to use the latest pytest 3.8.x release as it makes the test suite fail (so I guess that would be another PR with maybe some fixes in place).