### PR TITLE
Fix #25: allow using repeat(1) marker to disable repeat

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Release Notes
 -------------
 
+**0.9.0 (UNRELEASED)**
+
+* Using ``@pytest.mark.repeat(1)`` can now be used to disable repeating a test regardless of the ``--count`` parameter given in the command-line.
+
 **0.8.0 (2019-02-26)**
 
 * Fix mark deprecation warnings in new pytest versions.

--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -36,7 +36,9 @@ class UnexpectedError(Exception):
 
 @pytest.fixture(autouse=True)
 def __pytest_repeat_step_number(request):
-    if request.config.option.count > 1:
+    marker = request.keywords.get('repeat')
+    count = marker and marker.args[0] or request.config.option.count
+    if count > 1:
         try:
             return request.param
         except AttributeError:

--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -36,7 +36,7 @@ class UnexpectedError(Exception):
 
 @pytest.fixture(autouse=True)
 def __pytest_repeat_step_number(request):
-    marker = request.keywords.get('repeat')
+    marker = request.node.get_closest_marker("repeat")
     count = marker and marker.args[0] or request.config.option.count
     if count > 1:
         try:

--- a/test_repeat.py
+++ b/test_repeat.py
@@ -47,6 +47,17 @@ class TestRepeat:
         result.stdout.fnmatch_lines(['*3 passed*'])
         assert result.ret == 0
 
+    def test_mark_repeat_decorator_repeat_once(self, testdir):
+        testdir.makepyfile("""
+            import pytest
+            @pytest.mark.repeat(1)
+            def test_mark_repeat_decorator_repeat_once():
+                pass
+        """)
+        result = testdir.runpytest('--count', '10')
+        result.stdout.fnmatch_lines(['*1 passed*'])
+        assert result.ret == 0
+
     def test_parametrize(self, testdir):
         testdir.makepyfile("""
             import pytest


### PR DESCRIPTION
For instance:

```python
@pytest.mark.repeat(1)
def test_heavy():
    pass
```

When ran with  `py.test --count 10`, this doesn't crash anymore
and runs the test once.