### PR TITLE
Add pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel", "setuptools_scm"]
+build-backend = 'setuptools.build_meta'

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@
 # and then run "tox" from this directory.
 
 [tox]
+minversion = 3.4.0
+isolated_build = true
 envlist = py{27,34,35,36,py,py3}-pytest{36,37,38}, flake8
 
 [testenv]


### PR DESCRIPTION
We've been having a lot of fun struggling with `setup_requires` issues that do not occur for projects that have a PEP 518 `[build-system]`. First the issue was with `pytest`, but since `pytest` added support in https://github.com/pytest-dev/pytest/commit/af5d41fdfd70c99134165438dad44cf53d6076dd, the issues have landed on `pytest-repeat`. So, let's fix that...

- `MANIFEST.in` is needed to include `pyproject.toml` in sdists until https://github.com/pypa/setuptools/issues/1632 is resolved.
- `requires` in `pyproject.toml` uses the `pip` default minimum version of `setuptools` (https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support) and is otherwise set using guidance from the `setuptools_scm` project (https://github.com/pypa/setuptools_scm/commit/b4a0e9eb34a05d26ec4604057337867c1257db8c).
- Full (non-buggy) support for PEP 517 came in [Tox version 3.4.0](https://tox.readthedocs.io/en/latest/changelog.html#v3-4-0-2018-09-20), so that is specified in `minversion` as well as `isolated_build` (which tells Tox to "use a virtual environment to build a source distribution from the source tree" according to `[build-system]`).