### PR TITLE
GitHub Actions: Upgrade hynek/build-and-inspect-python-package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build and Check Package
-        uses: hynek/build-and-inspect-python-package@v1.5
+        uses: hynek/build-and-inspect-python-package@v2
 
   test:
 
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Download Package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Packages
         path: dist
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download Package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Packages
           path: dist


### PR DESCRIPTION
https://github.com/hynek/build-and-inspect-python-package/releases/tag/v2.0.0
> This release switches to actions/upload-artifact v4, which is incompatible with older versions of actions/download-artifact (and vice versa).
> * If you're using download-artifact@v3, do ___not___ upgrade.
> * If you want to use download-artifact@v4, you ___must___ upgrade.