### PR TITLE
Add option group for pytest-repeat arguments

### DIFF
--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -8,14 +8,15 @@ import pytest
 
 
 def pytest_addoption(parser):
-    parser.addoption(
+    group = parser.getgroup('pytest-repeat')
+    group.addoption(
         '--count',
         action='store',
         default=1,
         type=int,
         help='Number of times to repeat each test')
 
-    parser.addoption(
+    group.addoption(
         '--repeat-scope',
         action='store',
         default='function',


### PR DESCRIPTION
This organizes pytest-repeat arguments into its own option group using [getgroup](https://docs.pytest.org/en/latest/reference/reference.html#pytest.Parser.getgroup).

Closes #59 