### PR TITLE
Added `norepeat` marker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,32 @@ For example:
 This will attempt to run test_file.py 1000 times, but will stop as soon as a failure
 occurs.
 
+Ignoring a test for the repeat process
+--------------------------------------
+
+If you want to mark a test so it is ignored by the repeat process (so only ran once), you
+can use the :code:`@pytest.mark.norepeat` decorator:
+
+.. code-block:: python
+
+   import pytest
+
+
+   @pytest.mark.norepeat
+   def test_no_repeat_decorator():
+       pass
+
+   def test_repeat():
+       pass
+
+The following example would allow you to call for example:
+
+.. code-block:: bash
+
+  $ pytest --count=10 test_file.py
+
+and execute only :code:`test_repeat` 10 times and :code:`test_no_repeat_decorator` would only execute once.
+
 UnitTest Style Tests
 --------------------
 

--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -28,6 +28,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         'markers',
         'repeat(n): run the given test function `n` times.')
+    config.addinivalue_line(
+        'markers',
+        'norepeat: flag test to not be repeated.')
 
 
 class UnexpectedError(Exception):
@@ -57,7 +60,7 @@ def pytest_generate_tests(metafunc):
     m = metafunc.definition.get_closest_marker('repeat')
     if m is not None:
         count = int(m.args[0])
-    if count > 1:
+    if count > 1 and not metafunc.definition.get_closest_marker("norepeat"):
         metafunc.fixturenames.append("__pytest_repeat_step_number")
 
         def make_progress_id(i, n=count):

--- a/test_repeat.py
+++ b/test_repeat.py
@@ -269,3 +269,24 @@ class TestRepeat:
         """)
         result = testdir.runpytest('--count', '2', '--repeat-scope', 'a')
         assert result.ret == 4
+
+    def test_no_repeat_marker(self, testdir):
+        testdir.makepyfile("""
+            import pytest
+
+            @pytest.mark.norepeat
+            def test_no_repeat():
+                pass
+                           
+            def test_repeat():
+                pass               
+        """)
+
+        result = testdir.runpytest('-v', '--count', '2')
+        result.stdout.fnmatch_lines([
+            '*test_no_repeat_marker.py::test_no_repeat PASSED*',
+            '*test_no_repeat_marker.py::test_repeat[[]1-2[]] PASSED*',
+            '*test_no_repeat_marker.py::test_repeat[[]2-2[]] PASSED*',
+            '*3 passed*',
+        ])
+        assert result.ret == 0


### PR DESCRIPTION
Adds a `norepeat` (or could be changed to `no_repeat` if it feels better) marker that allows tests to be flagged so that using the CLI arguments won't trigger repeats on them.

My use case is that I want to repeat almost every tests of my suite (via the `--repeat-scope` argument) but I also wanted to flag a test or two that don't need to be (and slows down the suite).


Thanks for the nice pytest plugin 💯 