### PR TITLE
repeat tests change to happen after -k

### DIFF
--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -56,7 +56,7 @@ def pytest_generate_tests(metafunc):
     # Retrieve the configured count for repetitions
     count = metafunc.config.option.count
     
-    k_option = metafunc.config.getoption('k', None)
+    k_option = metafunc.config.option.keyword
 
     repeat_marker = metafunc.definition.get_closest_marker('repeat')
 
@@ -81,7 +81,7 @@ def pytest_generate_tests(metafunc):
             )
 
     if k_option:
-        if metafunc.definition.nodeid in metafunc.config._matchadd(k_option):
+        if k_option in metafunc.definition.nodeid:
             apply_repetition()
     else:
         apply_repetition()

--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -53,21 +53,35 @@ def __pytest_repeat_step_number(request):
 
 @pytest.hookimpl(trylast=True)
 def pytest_generate_tests(metafunc):
+    # Retrieve the configured count for repetitions
     count = metafunc.config.option.count
-    m = metafunc.definition.get_closest_marker('repeat')
-    if m is not None:
-        count = int(m.args[0])
-    if count > 1:
-        metafunc.fixturenames.append("__pytest_repeat_step_number")
+    
+    k_option = metafunc.config.getoption('k', None)
 
-        def make_progress_id(i, n=count):
-            return '{0}-{1}'.format(i + 1, n)
+    repeat_marker = metafunc.definition.get_closest_marker('repeat')
 
-        scope = metafunc.config.option.repeat_scope
-        metafunc.parametrize(
-            '__pytest_repeat_step_number',
-            range(count),
-            indirect=True,
-            ids=make_progress_id,
-            scope=scope
-        )
+    if repeat_marker is not None:
+        count = int(repeat_marker.args[0])
+
+    # function to add parameterization for test repetition
+    def apply_repetition():
+        if count > 1:
+            metafunc.fixturenames.append("__pytest_repeat_step_number")
+
+            def make_progress_id(i, n=count):
+                return '{0}-{1}'.format(i + 1, n)
+
+            scope = metafunc.config.option.repeat_scope
+            metafunc.parametrize(
+                '__pytest_repeat_step_number',
+                range(count),
+                indirect=True,
+                ids=make_progress_id,
+                scope=scope
+            )
+
+    if k_option:
+        if metafunc.definition.nodeid in metafunc.config._matchadd(k_option):
+            apply_repetition()
+    else:
+        apply_repetition()


### PR DESCRIPTION
[repeat tests change to happen after -k](https://github.com/pytest-dev/pytest-repeat/commit/e7bab37c09c7c07ff7b46e0079ce7c3f6cfcfe12)

**Based on actual measurements under tests , the performance will be improved by at least 2x to 10x.**


****This change will optimize the performance of repeat cases, especially when there are a huge number of tests. If the "-k" option exists, only the cases matched by "-k" will be repeated.**** 



# after optimize --> 18 passed, 9 deselected in 0.01s
```
# pytest -vv -s -k test_factorial_of_large_number --count 18

plugins: asyncio-0.24.0, cov-6.0.0, repeat-0.9.3, html-4.1.1, metadata-3.1.1, anyio-4.4.0, timeout-2.3.1, typeguard-4.3.0
asyncio: mode=Mode.STRICT, default_loop_scope=None
collected 27 items / 9 deselected / 18 selected                                                                                                                                 

test_a.py::TestMathFunctions::test_factorial_of_large_number[1-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[2-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[3-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[4-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[5-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[6-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[7-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[8-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[9-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[10-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[11-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[12-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[13-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[14-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[15-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[16-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[17-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[18-18] PASSED

======================================================================= 18 passed, 9 deselected in 0.01s
```

# before optimize --> 18 passed, 162 deselected in 0.02s
```
# pytest -vv -s -k test_factorial_of_large_number --count 18

**collected 180 items / 162 deselected** / 18 selected                                                                                                                              

test_a.py::TestMathFunctions::test_factorial_of_large_number[1-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[2-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[3-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[4-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[5-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[6-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[7-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[8-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[9-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[10-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[11-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[12-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[13-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[14-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[15-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[16-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[17-18] PASSED
test_a.py::TestMathFunctions::test_factorial_of_large_number[18-18] PASSED

====================================================================== 18 passed, 162 deselected in 0.02s =======================================================================
```

# pytest  -s --count 1 --collect-only -q
```
test_a.py::TestMathFunctions::test_add_positive
test_a.py::TestMathFunctions::test_add_negative
test_a.py::TestMathFunctions::test_divide
test_a.py::TestMathFunctions::test_divide_by_zero
test_a.py::TestMathFunctions::test_is_palindrome_true
test_a.py::TestMathFunctions::test_is_palindrome_false
test_a.py::TestMathFunctions::test_factorial_of_positive_number
test_a.py::TestMathFunctions::test_factorial_of_zero
test_a.py::TestMathFunctions::test_factorial_of_negative_number
test_a.py::TestMathFunctions::test_factorial_of_large_number
```