### PR TITLE
Support Python 3.13 and pytest 8, drop Python 3.7-3.8 and pytest 4

### DIFF
--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -10,6 +10,9 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build-package:
     name: Build & verify package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,19 +35,19 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         include:
           - python: "3.9"
-            tox_env: "py39-pytest7"
+            tox_env: "py39-pytest8"
           - python: "3.10"
-            tox_env: "py310-pytest7"
+            tox_env: "py310-pytest8"
           - python: "3.11"
-            tox_env: "py311-pytest7"
+            tox_env: "py311-pytest8"
           - python: "3.12"
-            tox_env: "py312-pytest7"
+            tox_env: "py312-pytest8"
           - python: "3.13"
-            tox_env: "py313-pytest7"
+            tox_env: "py313-pytest8"
           - python: "3.14"
-            tox_env: "py314-pytest7"
+            tox_env: "py314-pytest8"
           - python: "pypy3.10"
-            tox_env: "pypy3-pytest7"
+            tox_env: "pypy3-pytest8"
 
     steps:
     - uses: actions/checkout@v4
@@ -83,14 +83,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pytest: ["4", "5", "6"]
+        pytest: ["5", "6", "7"]
         include:
-          - pytest: "4"
-            tox_env: "py39-pytest4"
           - pytest: "5"
             tox_env: "py39-pytest5"
           - pytest: "6"
             tox_env: "py39-pytest6"
+          - pytest: "7"
+            tox_env: "py39-pytest7"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 
   pull_request:
 
+env:
+  FORCE_COLOR: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.10"]
         os: [ubuntu-latest, windows-latest]
         include:
           - python: "3.7"
@@ -46,6 +46,10 @@ jobs:
             tox_env: "py311-pytest7"
           - python: "3.12"
             tox_env: "py312-pytest7"
+          - python: "3.13"
+            tox_env: "py313-pytest7"
+          - python: "3.14"
+            tox_env: "py314-pytest7"
           - python: "pypy3.10"
             tox_env: "pypy3-pytest7"
 
@@ -62,6 +66,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
+        allow-prereleases: true
 
     - name: Install tox
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,13 +31,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.10"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.10"]
         os: [ubuntu-latest, windows-latest]
         include:
-          - python: "3.7"
-            tox_env: "py37-pytest7"
-          - python: "3.8"
-            tox_env: "py38-pytest7"
           - python: "3.9"
             tox_env: "py39-pytest7"
           - python: "3.10"
@@ -90,11 +86,11 @@ jobs:
         pytest: ["4", "5", "6"]
         include:
           - pytest: "4"
-            tox_env: "py37-pytest4"
+            tox_env: "py39-pytest4"
           - pytest: "5"
-            tox_env: "py37-pytest5"
+            tox_env: "py39-pytest5"
           - pytest: "6"
-            tox_env: "py37-pytest6"
+            tox_env: "py39-pytest6"
 
     steps:
       - uses: actions/checkout@v4
@@ -108,7 +104,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.9"
 
       - name: Install tox
         run: |

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Requirements
 
 You will need the following prerequisites in order to use pytest-repeat:
 
-- Python 3.7+ or PyPy3
+- Python 3.9+ or PyPy3
 - pytest 4 or newer
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Requirements
 You will need the following prerequisites in order to use pytest-repeat:
 
 - Python 3.9+ or PyPy3
-- pytest 4 or newer
+- pytest 5 or newer
 
 Installation
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Quality Assurance",
   "Topic :: Software Development :: Testing",
   "Topic :: Utilities",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "pytest plugin for repeating tests"
 readme = "README.rst"
 license = {file = "LICENSE"}
 authors = [{name = "Bob Silverberg"}]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: Pytest",
@@ -15,8 +15,6 @@ classifiers = [
   "Operating System :: POSIX",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pytest_repeat.py
+++ b/pytest_repeat.py
@@ -61,7 +61,7 @@ def pytest_generate_tests(metafunc):
         metafunc.fixturenames.append("__pytest_repeat_step_number")
 
         def make_progress_id(i, n=count):
-            return '{0}-{1}'.format(i + 1, n)
+            return f'{i + 1}-{n}'
 
         scope = metafunc.config.option.repeat_scope
         metafunc.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 minversion = 4.0
 isolated_build = true
 envlist =
-  py{310,311,312,313,314,py3}-pytest7
-  py39-pytest{4,5,6}
+  py{310,311,312,313,314,py3}-pytest8
+  py39-pytest{5,6,7}
   flake8
 
 
@@ -12,10 +12,10 @@ commands = pytest {posargs}
 package = wheel
 wheel_build_env = .pkg
 deps =
-    pytest4: pytest~=4.6
     pytest5: pytest~=5.4
     pytest6: pytest~=6.2
     pytest7: pytest>=7
+    pytest8: pytest>=8
 
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 minversion = 4.0
 isolated_build = true
 envlist =
-  py{37,38,39,310,311,312,313,314,py3}-pytest7
-  py37-pytest{4,5,6}
+  py{310,311,312,313,314,py3}-pytest7
+  py39-pytest{4,5,6}
   flake8
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 4.0
 isolated_build = true
 envlist =
-  py{37,38,39,310,311,312,py3}-pytest7
+  py{37,38,39,310,311,312,313,314,py3}-pytest7
   py37-pytest{4,5,6}
   flake8
 


### PR DESCRIPTION
Python 3.7-3.8 are EOL.

Also test Python 3.14, soon in beta.

https://devguide.python.org/versions/

Test and support the last four versions of pytest, 5-8 instead of 4-7.

And add colour to GitHub Actions logs for readability.